### PR TITLE
Move tests to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,6 @@ include LICENSE
 include requirements.txt
 recursive-include docs *
 recursive-include rest_framework_fine_permissions/templates *.html
+include runtests.py
+include tox.ini
+recursive-include tests *.py

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('requirements.txt') as requirements:
 setup(
     name='djangorestframework-fine-permissions',
     version='0.8.0',
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     install_requires=libraries,
     dependency_links=dependency_links,
     include_package_data=True,


### PR DESCRIPTION
Tests shouldnt be installed.
They are useful in the sdist, and add runtests.py and tox.ini
to make it easier to run tests.